### PR TITLE
Move `types-requests` to `dev` dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,7 @@ dependencies = [
   "h5netcdf==1.3.0",
   "mypy==1.11.2",
   "matplotlib==3.7.5",
-  "rtree==1.1.0",
-  "types-requests~=2.32.0"
+  "rtree==1.1.0"
   ]
 
 [project.urls]
@@ -42,6 +41,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+  "types-requests~=2.32.0"
 ]
 train = [
 ]


### PR DESCRIPTION
The `types-requests` lib is used to run `mypy` during development of the package. Putting it in general requirements leads to downstream conflicts, e.g. when adding `prometheo` as requirement to `worldcereal-classification`. This PR moves `types-requests` to `dev` dependencies so it does not get installed by default with prometheo.