### PR TITLE
Device and types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ gha-creds-*.json
 .vscode
 scrap
 imgs
+*.egg-info/

--- a/prometheo/datasets/scaleag.py
+++ b/prometheo/datasets/scaleag.py
@@ -6,14 +6,8 @@ import pandas as pd
 from loguru import logger
 from torch.utils.data import Dataset
 
-from prometheo.predictors import (
-    DEM_BANDS,
-    METEO_BANDS,
-    NODATAVALUE,
-    S1_BANDS,
-    S2_BANDS,
-    Predictors,
-)
+from prometheo.predictors import (DEM_BANDS, METEO_BANDS, NODATAVALUE,
+                                  S1_BANDS, S2_BANDS, Predictors)
 
 
 class ScaleAgDataset(Dataset):
@@ -289,6 +283,7 @@ class ScaleAgDataset(Dataset):
         time_dim = 1
         valid_idx = valid_positions or np.arange(time_dim)
 
+        assert self.num_outputs is not None, "num_outputs must be set"
         labels = np.full(
             (1, 1, time_dim, self.num_outputs),
             fill_value=NODATAVALUE,
@@ -310,8 +305,6 @@ class ScaleAgDataset(Dataset):
         # convert classes to indices for multiclass
         elif self.task_type == "multiclass":
             target = self.class_to_index[target]
-            if target.size > 1:
-                target = target.to_numpy()
         labels[0, 0, valid_idx, :] = target
         return labels
 

--- a/prometheo/datasets/worldcereal.py
+++ b/prometheo/datasets/worldcereal.py
@@ -1,18 +1,12 @@
 from datetime import datetime
-from typing import Dict, List, Literal, Optional, Tuple
+from typing import Dict, List, Literal, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
 from torch.utils.data import Dataset
 
-from prometheo.predictors import (
-    DEM_BANDS,
-    METEO_BANDS,
-    NODATAVALUE,
-    S1_BANDS,
-    S2_BANDS,
-    Predictors,
-)
+from prometheo.predictors import (DEM_BANDS, METEO_BANDS, NODATAVALUE,
+                                  S1_BANDS, S2_BANDS, Predictors)
 
 
 class WorldCerealDataset(Dataset):
@@ -339,11 +333,12 @@ class WorldCerealLabelledDataset(WorldCerealDataset):
         """
 
         label = self.initialize_label()
+        valid_idx: Union[int, np.ndarray]
         if not self.time_explicit:
             # We have only one label for the whole sequence
             valid_idx = 0
         else:
-            valid_idx = valid_position or np.arange(self.num_timesteps)
+            valid_idx = valid_position if valid_position is not None else np.arange(self.num_timesteps)
 
         if task_type == "cropland":
             label[0, 0, valid_idx, :] = int(row_d["LANDCOVER_LABEL"] == 11)

--- a/prometheo/finetune.py
+++ b/prometheo/finetune.py
@@ -138,7 +138,6 @@ def _train_loop(
             true_labels = val_targets.long().squeeze(-1).cpu()
 
         # accuracy & # macro F1
-        from sklearn.metrics import f1_score
         current_val_acc = pred_labels.eq(true_labels).float().mean().item()
         current_val_f1  = f1_score(
             true_labels.numpy(), pred_labels.numpy(),

--- a/prometheo/models/presto/wrapper.py
+++ b/prometheo/models/presto/wrapper.py
@@ -378,9 +378,13 @@ class PretrainedPrestoWrapper(nn.Module):
         if not isinstance(x.latlon, torch.Tensor):
             raise TypeError(f"Expected latlon to be torch.Tensor, got {type(x.latlon)}")
 
+        if not isinstance(dynamic_world, torch.Tensor):
+            dynamic_world = torch.tensor(dynamic_world, device=device)
+
+        dynamic_world = dynamic_world.to(device=device, dtype=torch.long)
         embeddings = self.encoder(
             x=s1_s2_era5_srtm.float(),
-            dynamic_world=torch.tensor(dynamic_world, device=device).long(),
+            dynamic_world=dynamic_world,
             latlons=x.latlon.float(),
             mask=mask.long(),
             month=x.timestamps[:, :, 1] - 1,

--- a/prometheo/predictors.py
+++ b/prometheo/predictors.py
@@ -53,7 +53,7 @@ class Predictors(NamedTuple):
     # for now we ignore them
     # aux_inputs: Optional[List[ArrayTensor]] = None
     # Label needs to always be 2D, with temporal dimension
-    label: Optional[ArrayTensor] = None  # [B, H, W, T, num_outputs]
+    label: Optional[ArrayTensor] = None  # [B, H, W, T, 1]
     timestamps: Optional[ArrayTensor] = None  # [B, T, D=3], where D=[day, month, year]
 
     def as_dict(self, ignore_nones: bool = True):
@@ -65,7 +65,7 @@ class Predictors(NamedTuple):
             else:
                 return_dict[field] = val
         return return_dict
-    
+
     def move_predictors_to_device(self, device: torch.device = device) -> "Predictors":
         # Define custom dtypes for specific fields
         expected_dtypes = {
@@ -82,7 +82,8 @@ class Predictors(NamedTuple):
         return self._replace(
             **{
                 field: to_torchtensor(val, device, expected_dtypes.get(field, None))
-                if isinstance(val, (np.ndarray, torch.Tensor)) else val
+                if isinstance(val, (np.ndarray, torch.Tensor))
+                else val
                 for field, val in self._asdict().items()
             }
         )
@@ -92,6 +93,3 @@ def collate_fn(batch: Sequence[Predictors]):
     # we assume that the same values are consistently None
     collated_dict = default_collate([i.as_dict(ignore_nones=True) for i in batch])
     return Predictors(**collated_dict)
-
-
-

--- a/prometheo/utils.py
+++ b/prometheo/utils.py
@@ -48,14 +48,18 @@ def initialize_logging(
         "<level>{message}</level>"
     )
 
+    log_filter = (
+        (lambda record: console_filter_keyword not in record["message"])
+        if console_filter_keyword is not None
+        else None
+    )
+
     # Re-add console handler with optional filtering
     logger.add(
         sys.stdout,
         level=level,
         format=custom_format,
-        filter=lambda record: console_filter_keyword not in record["message"]
-        if console_filter_keyword
-        else None,
+        filter=log_filter,
     )
 
     # File handler

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "tqdm==4.64.1",
   "xarray>=2023.1.0",
   "requests==2.32.3",
-  "scikit-learn==1.5.0",
+  "scikit-learn==1.6.1",
   "fastparquet",
   "h5netcdf==1.3.0",
   "mypy==1.11.2",

--- a/tests/test_finetuning.py
+++ b/tests/test_finetuning.py
@@ -6,6 +6,7 @@ import pandas as pd
 from loguru import logger
 from torch.nn import BCEWithLogitsLoss
 from torch.optim import AdamW, lr_scheduler
+from torch.utils.data import DataLoader
 
 from prometheo import finetune
 from prometheo.datasets import WorldCerealLabelledDataset
@@ -31,6 +32,9 @@ class TestFinetuning(TestCase):
         train_ds = WorldCerealLabelledDataset(df)
         val_ds = WorldCerealLabelledDataset(df)
 
+        train_dl = DataLoader(train_ds, batch_size=2, shuffle=True)
+        val_dl = DataLoader(val_ds, batch_size=2, shuffle=False)
+
         # Construct the model with finetuning head
         model = Presto(num_outputs=train_ds.num_outputs, regression=False)
 
@@ -41,8 +45,8 @@ class TestFinetuning(TestCase):
         with tempfile.TemporaryDirectory(dir=".") as output_dir:
             finetune.run_finetuning(
                 model,
-                train_ds,
-                val_ds,
+                train_dl,
+                val_dl,
                 experiment_name="test",
                 output_dir=output_dir,
                 loss_fn=BCEWithLogitsLoss(),
@@ -59,6 +63,9 @@ class TestFinetuning(TestCase):
         train_ds = WorldCerealLabelledDataset(df, time_explicit=True)
         val_ds = WorldCerealLabelledDataset(df, time_explicit=True)
 
+        train_dl = DataLoader(train_ds, batch_size=2, shuffle=True)
+        val_dl = DataLoader(val_ds, batch_size=2, shuffle=False)
+
         # Construct the model with finetuning head
         model = Presto(num_outputs=train_ds.num_outputs, regression=False)
 
@@ -72,8 +79,8 @@ class TestFinetuning(TestCase):
         with tempfile.TemporaryDirectory(dir=".") as output_dir:
             finetune.run_finetuning(
                 model,
-                train_ds,
-                val_ds,
+                train_dl,
+                val_dl,
                 experiment_name="test_advanced",
                 output_dir=output_dir,
                 loss_fn=BCEWithLogitsLoss(),

--- a/tests/test_predictors.py
+++ b/tests/test_predictors.py
@@ -1,0 +1,106 @@
+import unittest
+
+import numpy as np
+import torch
+
+from prometheo.predictors import Predictors
+from prometheo.utils import device
+
+
+class TestPredictorsDevice(unittest.TestCase):
+    def test_move_predictors_to_device_with_numpy(self):
+        predictors = Predictors(
+            s1=np.ones((2, 1, 1, 12, 2), dtype=np.float32),
+            s2=None,
+            meteo=np.ones((2, 12, 2), dtype=np.float32),
+            dem=None,
+            latlon=np.ones((2, 2), dtype=np.float32),
+            label=np.zeros((2, 1, 1, 1, 1), dtype=np.float32),
+            timestamps=np.array([[1, 1, 2021]] * 2).reshape(2, 1, 3)
+        )
+
+        moved = predictors.move_predictors_to_device(device)
+
+        for key, val in moved._asdict().items():
+            if isinstance(val, torch.Tensor):
+                self.assertEqual(val.device, device)
+                self.assertIsInstance(val, torch.Tensor)
+
+    def test_move_predictors_to_device_with_mixed_types(self):
+        predictors = Predictors(
+            s1=torch.randn(2, 1, 1, 12, 2),
+            meteo=np.random.rand(2, 12, 2),
+            latlon=None,
+            dem=None,
+            label=None,
+            s2=None,
+            timestamps=None
+        )
+        moved = predictors.move_predictors_to_device()
+        self.assertTrue(moved.s1.device == device)
+        self.assertTrue(moved.meteo.device == device)
+
+    # Why: Ensures you can safely unpack predictors and avoid silent None propagation.
+    def test_as_dict_with_and_without_ignore_nones(self):
+        predictors = Predictors(
+            s1=torch.rand(1), s2=None, meteo=None, dem=None, latlon=torch.rand(1), label=None, timestamps=None
+        )
+        d1 = predictors.as_dict(ignore_nones=True)
+        d2 = predictors.as_dict(ignore_nones=False)
+
+        self.assertIn("s1", d1)
+        self.assertNotIn("s2", d1)
+        self.assertIn("s2", d2)
+        self.assertIsNone(d2["s2"])
+
+    # Why: NamedTuple is immutable — this ensures you're returning a new instance.
+    def test_move_predictors_to_device_returns_new_instance(self):
+        predictors = Predictors(
+            s1=np.ones((1, 1, 1, 1, 2), dtype=np.float32),
+            s2=None, meteo=None, dem=None, latlon=None, label=None, timestamps=None
+        )
+        moved = predictors.move_predictors_to_device(device)
+
+        self.assertIsNot(predictors, moved)
+        self.assertEqual(predictors.s1.dtype, np.float32)
+        self.assertTrue(isinstance(moved.s1, torch.Tensor))
+
+    # Why: Makes sure functions like .as_dict() or .move_predictors_to_device() don't crash when all values are None.
+    def test_all_fields_none_safe_handling(self):
+        predictors = Predictors()  # All default to None
+        self.assertEqual(predictors.as_dict(), {})
+
+        moved = predictors.move_predictors_to_device(device)
+        self.assertIsInstance(moved, Predictors)
+
+    # Why: Validates custom collate_fn handles variable presence of inputs correctly.
+    def test_collate_fn_correctness(self):
+        from prometheo.predictors import collate_fn
+        batch = [
+            Predictors(
+                s1=torch.rand(1,1,1,12,2),
+                s2=None,
+                meteo=torch.rand(1,12,2),
+                dem=None,
+                latlon=torch.rand(1,2),
+                label=torch.rand(1,1,1,1,1),
+                timestamps=torch.randint(0, 12, (1,12,3))
+            ) for _ in range(3)
+        ]
+        collated = collate_fn(batch)
+        self.assertEqual(collated.s1.shape[0], 3)
+        self.assertEqual(collated.meteo.shape[0], 3)
+
+    def test_to_torchtensor_converts_numpy_and_preserves_tensor(self):
+        from prometheo.predictors import to_torchtensor
+
+        arr = np.ones((3,))
+        tensor = torch.tensor([1.0, 2.0])
+
+        converted = to_torchtensor(arr, device)
+        self.assertIsInstance(converted, torch.Tensor)
+        self.assertEqual(converted.device, device)
+
+        already_tensor = to_torchtensor(tensor, device)
+        self.assertEqual(already_tensor.device, device)
+

--- a/tests/test_presto.py
+++ b/tests/test_presto.py
@@ -5,7 +5,9 @@ import torch
 from einops import repeat
 
 from prometheo.models import Presto
-from prometheo.predictors import DEM_BANDS, METEO_BANDS, S1_BANDS, S2_BANDS, Predictors
+from prometheo.predictors import (DEM_BANDS, METEO_BANDS, S1_BANDS, S2_BANDS,
+                                  Predictors)
+from prometheo.utils import device
 
 
 class TestPresto(unittest.TestCase):
@@ -21,8 +23,8 @@ class TestPresto(unittest.TestCase):
             latlon=np.random.rand(b, 2),
             label=np.ones((b, 1, 1, 1, 1)),
             timestamps=repeat(timestamps_per_instance, "t d -> b t d", b=b),
-        )
-        model = Presto()
+        ).move_predictors_to_device(device)
+        model = Presto().to(device)
         output_embeddings = model(x)
         self.assertEqual(
             output_embeddings.shape, (b, h, w, 1, model.encoder.embedding_size)
@@ -36,14 +38,14 @@ class TestPresto(unittest.TestCase):
             s1=np.random.rand(b, h, w, t, len(S1_BANDS)),
             latlon=np.random.rand(b, 2),
             timestamps=repeat(timestamps_per_instance, "t d -> b t d", b=b),
-        )
-        model = Presto()
+        ).move_predictors_to_device(device)
+        model = Presto().to(device)
         output_embeddings = model(x, eval_pooling="time")
         self.assertEqual(
             output_embeddings.shape, (b, h, w, t, model.encoder.embedding_size)
         )
 
-        model = Presto()
+        model = Presto().to(device)
         output_embeddings = model(x)
         self.assertEqual(
             output_embeddings.shape, (b, h, w, 1, model.encoder.embedding_size)
@@ -83,8 +85,8 @@ class TestPresto(unittest.TestCase):
             latlon=np.random.rand(b, 2),
             label=np.ones((b, h, w, t, 1)),
             timestamps=repeat(timestamps_per_instance, "t d -> b t d", b=b),
-        )
-        model = Presto()
+        ).move_predictors_to_device(device)
+        model = Presto().to(device)
         output_embeddings = model(x)
         self.assertEqual(
             output_embeddings.shape, (b, h, w, t, model.encoder.embedding_size)
@@ -101,8 +103,8 @@ class TestPresto(unittest.TestCase):
             dem=np.random.rand(b, h, w, len(DEM_BANDS)),
             latlon=np.random.rand(b, 2),
             timestamps=repeat(timestamps_per_instance, "t d -> b t d", b=b),
-        )
-        model = Presto()
+        ).move_predictors_to_device(device)
+        model = Presto().to(device)
         output_embeddings = model(x, eval_pooling=None)
         self.assertEqual(
             output_embeddings[0].shape, (b, 34, model.encoder.embedding_size)

--- a/tests/test_scaleag_dataset.py
+++ b/tests/test_scaleag_dataset.py
@@ -6,7 +6,9 @@ from torch.utils.data import DataLoader
 
 from prometheo.datasets import ScaleAgDataset
 from prometheo.models import Presto
-from prometheo.predictors import DEM_BANDS, METEO_BANDS, S1_BANDS, S2_BANDS, collate_fn
+from prometheo.predictors import (DEM_BANDS, METEO_BANDS, S1_BANDS, S2_BANDS,
+                                  collate_fn)
+from prometheo.utils import device
 
 models_to_test = [Presto]
 
@@ -64,7 +66,8 @@ class TestDataset(TestCase):
         self.check_batch(batch, batch_size, 12)
 
         for model_cls in models_to_test:
-            model = model_cls()
+            model = model_cls().to(device)
+            batch = batch.move_predictors_to_device(device)
             output = model(batch)
             self.assertEqual(
                 output.shape[0],
@@ -83,7 +86,8 @@ class TestDataset(TestCase):
         self.check_batch(batch, batch_size, num_timesteps)
 
         for model_cls in models_to_test:
-            model = model_cls()
+            model = model_cls().to(device)
+            batch = batch.move_predictors_to_device(device)
             output = model(batch)
             self.assertEqual(
                 output.shape[0],
@@ -111,7 +115,8 @@ class TestDataset(TestCase):
         self.assertTrue((batch.label.unique().numpy() == [0, 1]).all())
 
         for model_cls in models_to_test:
-            model = model_cls()
+            model = model_cls().to(device)
+            batch = batch.move_predictors_to_device(device)
             output = model(batch)
             self.assertEqual(
                 output.shape[0],
@@ -180,7 +185,8 @@ class TestDataset(TestCase):
         self.check_batch(batch, batch_size, num_timesteps, num_outputs=1)
 
         for model_cls in models_to_test:
-            model = model_cls()
+            model = model_cls().to(device)
+            batch = batch.move_predictors_to_device(device)
             output = model(batch)
             self.assertEqual(
                 output.shape[0],
@@ -224,7 +230,8 @@ class TestDataset(TestCase):
             )
 
         for model_cls in models_to_test:
-            model = model_cls()
+            model = model_cls().to(device)
+            batch = batch.move_predictors_to_device(device)
             output = model(batch)
             self.assertEqual(
                 output.shape[0],

--- a/tests/test_worldcereal_dataset.py
+++ b/tests/test_worldcereal_dataset.py
@@ -6,19 +6,12 @@ from resources import load_dataframe
 from torch.utils.data import DataLoader
 
 from prometheo.datasets import WorldCerealDataset, WorldCerealLabelledDataset
-from prometheo.datasets.worldcereal import (
-    get_dekad_timestamp_components,
-    get_monthly_timestamp_components,
-)
+from prometheo.datasets.worldcereal import (get_dekad_timestamp_components,
+                                            get_monthly_timestamp_components)
 from prometheo.models import Presto
-from prometheo.predictors import (
-    DEM_BANDS,
-    METEO_BANDS,
-    NODATAVALUE,
-    S1_BANDS,
-    S2_BANDS,
-    collate_fn,
-)
+from prometheo.predictors import (DEM_BANDS, METEO_BANDS, NODATAVALUE,
+                                  S1_BANDS, S2_BANDS, collate_fn)
+from prometheo.utils import device
 
 models_to_test = [Presto]
 
@@ -73,7 +66,8 @@ class TestDataset(TestCase):
         self.check_batch(batch, batch_size, 12)
 
         for model_cls in models_to_test:
-            model = model_cls()
+            model = model_cls().to(device)
+            batch = batch.move_predictors_to_device(device)
             output = model(batch)
             self.assertEqual(
                 output.shape[0],
@@ -92,7 +86,8 @@ class TestDataset(TestCase):
         self.check_batch(batch, batch_size, num_timesteps)
 
         for model_cls in models_to_test:
-            model = model_cls()
+            model = model_cls().to(device)
+            batch = batch.move_predictors_to_device(device)
             output = model(batch)
             self.assertEqual(
                 output.shape[0],
@@ -113,7 +108,8 @@ class TestDataset(TestCase):
         self.assertTrue((np.isin(batch.label.unique().numpy(), [0, NODATAVALUE])).all())
 
         for model_cls in models_to_test:
-            model = model_cls()
+            model = model_cls().to(device)
+            batch = batch.move_predictors_to_device(device)
             output = model(batch)
             self.assertEqual(
                 output.shape[0],
@@ -134,7 +130,8 @@ class TestDataset(TestCase):
         self.assertTrue((batch.label.unique().numpy() == 0).all())
 
         for model_cls in models_to_test:
-            model = model_cls()
+            model = model_cls().to(device)
+            batch = batch.move_predictors_to_device(device)
             output = model(batch)
             self.assertEqual(
                 output.shape[0],
@@ -161,7 +158,8 @@ class TestDataset(TestCase):
         self.check_batch(batch, batch_size, num_timesteps, num_outputs=num_outputs)
 
         for model_cls in models_to_test:
-            model = model_cls()
+            model = model_cls().to(device)
+            batch = batch.move_predictors_to_device(device)
             output = model(batch)
             self.assertEqual(
                 output.shape[0],


### PR DESCRIPTION
## Summary of changes
| What changed                                | Status    | Necessary? | Why?                                                             |
| ----------------------------------- | --------- | ---------- | ---------------------------------------------------------------- |
| `to_torchtensor()`                  | Changed   | ✅          | Adds dtype/device control for safety                             |
| `move_predictors_to_device()`       | Added     | ✅          | Shifts device handling responsibility to caller (cleaner design) |
| `dataset_to_model()`                | Rewritten | ✅          | Uses `torch` instead of `numpy`; enables GPU support             |
| `normalize()`                       | Updated   | ✅          | Fixes device mismatch in `normalize()` ops                       |
| `PretrainedPrestoWrapper.forward()` | Cleaned   | ✅          | Assumes input is already clean; avoids deep `to(device)`         |
| updated tests | Updated| ✅          | Existing tests got updated to account for the changes         |
| `test_predictors.py` | Added| ✅          | Added a dedicated test for `Predictors` class         |

## More details for major changes
### **move_predictors_to_device()** – New Method
**Purpose:** Encapsulates device/dtype transformation for all fields.

**Why it’s needed:** 
- Makes the Predictors more contract explicit
- Prevents the need for to_torchtensor() scattered in training, evaluation, tests
- Avoids costly and fragile re-checking in the model

**Example Failure Without It:**
```
batch = Predictors(s1=np.random.rand(...))
model(batch)  # ❌ device or dtype mismatch at runtime
```
### **dataset_to_model()** – Tensor Rewrite
**OLD:**
- Relied on np.zeros, np.ones
- Used mixed np and torch during normalization
- Created dynamic_world as NumPy array
**NEW:**
- Fully uses torch.zeros, torch.ones, torch.full
- All tensors are on device, safe for GPU use

**Justification:** 
- Prevents runtime errors (e.g., can't assign numpy to torch.cuda)
- Makes the function usable in mixed CPU/GPU workflows

**Example Silent Bug:**
```
if x.s1 is not None:
    s1_hw = x.s1[:, 0, 0, :, :]
    output[:, :, idx] = s1_hw  # 💥 fails if output is torch, s1_hw is numpy
```

### `PretrainedPrestoWrapper.forward()` Cleanup
**OLD:**
```
# Every input to encoder wrapped in `to_torchtensor(...)``
```
**NEW:**
```
# Assumes x already clean (uses .float(), .long(), etc.)
```

**Justification:**
- Moves device responsibility upstream (tests/train loop)
- Avoids repeated conversion on each forward pass
- Encourages batching best practices