### PR TITLE
Also filter `divide` and not only `true_divide`

### DIFF
--- a/prometheo/models/presto/wrapper.py
+++ b/prometheo/models/presto/wrapper.py
@@ -106,6 +106,7 @@ def calculate_ndvi(input_array):
         warnings.filterwarnings(
             "ignore", message="invalid value encountered in true_divide"
         )
+        warnings.filterwarnings("ignore", message="invalid value encountered in divide")
         # suppress the following warning
         # RuntimeWarning: invalid value encountered in true_divide
         # for cases where near_infrared + red == 0


### PR DESCRIPTION
We have a lot of annoying warnings because apparently we only scan for `true_divide` while in our setup the warning is `divide`. This PR also filters out this warning.