### PR TITLE
Add time-explicit inference to WorldCereal dataset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "prometheo"
-version = "0.0.1"
+version = "0.0.2"
 description = "PromethEO Repository"
 authors = [
   { name="Gabriel Tseng", email="gabriel.tseng@gmail.com" },

--- a/tests/test_worldcereal_dataset.py
+++ b/tests/test_worldcereal_dataset.py
@@ -14,6 +14,7 @@ from prometheo.datasets.worldcereal import (
     run_model_inference,
 )
 from prometheo.models import Presto
+from prometheo.models.pooling import PoolingMethods
 from prometheo.models.presto.wrapper import (
     DEM_BANDS,
     METEO_BANDS,
@@ -548,6 +549,17 @@ class TestInference(unittest.TestCase):
         )
 
         assert presto_features.dims == ref_presto_features.dims
+
+        # Check run_model_inference with pooling method TIME
+        # This should return a 4D array with the temporal dimension preserved
+        presto_features = run_model_inference(
+            arr,
+            presto_model,
+            batch_size=512,
+            epsg=32631,
+            pooling_method=PoolingMethods.TIME,
+        )
+        assert presto_features.shape == (100, 100, 12, 128)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
To support time-explicit embeddings computation for WorldCereal, we need to add a `pooling_method` kwarg and correctly deal with the dimensions of the resulting features array. This PR aims to take care of that.