### PR TITLE
Fix NDVI mask propagation in normalize()

### DIFF
--- a/prometheo/models/presto/wrapper.py
+++ b/prometheo/models/presto/wrapper.py
@@ -137,15 +137,32 @@ def normalize(x: np.ndarray, mask: np.ndarray):
     else:
         x = (x + torch.tensor(BANDS_ADD)) / torch.tensor(BANDS_DIV)
 
-    ndvi, ndvi_mask = calculate_ndvi(x)
+    ndvi, _ = calculate_ndvi(x)
+
+    # Derive the NDVI mask from the upstream B4 / B8 masks rather than
+    # recomputing it from the (already-normalized) values. The recomputed
+    # ndvi_mask checks `band == NODATAVALUE` on values that have been
+    # divided by 10000, so masked positions look "valid" with NDVI = 0.
+    b4_idx, b8_idx, ndvi_idx = (
+        BANDS.index("B4"),
+        BANDS.index("B8"),
+        BANDS.index("NDVI"),
+    )
+    if isinstance(x, np.ndarray):
+        ndvi_mask_from_input = np.logical_or(
+            mask[..., b4_idx], mask[..., b8_idx]
+        )
+    else:
+        ndvi_mask_from_input = torch.logical_or(
+            mask[..., b4_idx].bool(), mask[..., b8_idx].bool()
+        )
 
     if len(x.shape) == 2:
-        x[:, BANDS.index("NDVI")] = ndvi
-        mask[:, BANDS.index("NDVI")] = ndvi_mask
-
+        x[:, ndvi_idx] = ndvi
+        mask[:, ndvi_idx] = ndvi_mask_from_input
     else:
-        x[:, :, BANDS.index("NDVI")] = ndvi
-        mask[:, :, BANDS.index("NDVI")] = ndvi_mask
+        x[:, :, ndvi_idx] = ndvi
+        mask[:, :, ndvi_idx] = ndvi_mask_from_input
     return x, mask
 
 

--- a/tests/test_presto.py
+++ b/tests/test_presto.py
@@ -6,7 +6,16 @@ from einops import repeat
 
 from prometheo.models import Presto
 from prometheo.models.pooling import PoolingMethods
-from prometheo.predictors import DEM_BANDS, METEO_BANDS, S1_BANDS, S2_BANDS, Predictors
+from prometheo.models.presto.single_file_presto import BANDS
+from prometheo.models.presto.wrapper import dataset_to_model
+from prometheo.predictors import (
+    DEM_BANDS,
+    METEO_BANDS,
+    NODATAVALUE,
+    S1_BANDS,
+    S2_BANDS,
+    Predictors,
+)
 
 
 class TestPresto(unittest.TestCase):
@@ -146,3 +155,45 @@ class TestPresto(unittest.TestCase):
         self.assertEqual(
             output_embeddings.shape, (b, h, w, t, model.encoder.embedding_size)
         )
+
+
+class TestNormalize(unittest.TestCase):
+    def test_ndvi_mask_propagated_at_masked_s2_timesteps(self):
+        # Regression: when S2 is masked at the input, the NDVI position
+        # emitted by dataset_to_model must also be masked. A previous bug
+        # recomputed the NDVI mask from already-normalized values, so masked
+        # positions arrived at the encoder as a "valid" NDVI = 0 phantom token.
+        b, t, h, w = 1, 4, 1, 1
+        s2 = np.full((b, h, w, t, len(S2_BANDS)), 2000.0, dtype=np.float32)
+        s2[..., S2_BANDS.index("B8")] = 4000.0
+        s2[..., S2_BANDS.index("B4")] = 1000.0
+        # Mask timesteps 1 and 2 entirely.
+        s2[:, :, :, 1:3, :] = NODATAVALUE
+
+        s1 = np.full((b, h, w, t, len(S1_BANDS)), -10.0, dtype=np.float32)
+        meteo = np.full((b, h, w, t, len(METEO_BANDS)), 15.0, dtype=np.float32)
+        dem = np.full((b, h, w, len(DEM_BANDS)), 100.0, dtype=np.float32)
+        latlon = np.zeros((b, h, w, 2), dtype=np.float32)
+        timestamps = np.stack(
+            [np.array([1, 1 + ts, 2024], dtype=np.int32) for ts in range(t)]
+        )[None, ...]
+
+        x = Predictors(
+            s1=s1,
+            s2=s2,
+            meteo=meteo,
+            dem=dem,
+            latlon=latlon,
+            timestamps=timestamps,
+        )
+        _, mask, *_ = dataset_to_model(x)
+
+        ndvi_idx = BANDS.index("NDVI")
+        # Shape after rearrange: [B*H*W, T, total_bands]
+        ndvi_mask_per_timestep = mask[:, :, ndvi_idx].astype(bool)
+        # Timesteps 1 and 2 had S2 fully masked -> NDVI must be masked there.
+        self.assertTrue(ndvi_mask_per_timestep[0, 1])
+        self.assertTrue(ndvi_mask_per_timestep[0, 2])
+        # Timesteps 0 and 3 had real S2 -> NDVI must be unmasked there.
+        self.assertFalse(ndvi_mask_per_timestep[0, 0])
+        self.assertFalse(ndvi_mask_per_timestep[0, 3])

--- a/tests/test_worldcereal_dataset.py
+++ b/tests/test_worldcereal_dataset.py
@@ -522,7 +522,12 @@ class TestInference(unittest.TestCase):
                 )
         presto_features.to_netcdf(data_dir / "test_presto_inference_features.nc")
 
-        Features were regenerated at commit 6f0f7d6 since this fixed a bug with dtypes
+        Features were regenerated at commit 6f0f7d6 since this fixed a bug with dtypes.
+        Features were regenerated again on the ndvi-masking-fix branch because the
+        NDVI mask fix in normalize() correctly drops NDVI tokens at masked S2
+        timesteps; previously they were left "valid" with a phantom NDVI=0, so the
+        encoder's pooled embedding differs slightly post-fix for any input with
+        cloud-masked S2 timesteps.
         """
         arr = xr.open_dataarray(data_dir / "test_inference_array.nc")
 


### PR DESCRIPTION
The NDVI mask was recomputed inside `calculate_ndvi()` from the already-normalized values: NODATAVALUE (65535) had been divided by BANDS_DIV (10000) into 6.5535, so the `band == NODATAVALUE` check never matched and the NDVI position arrived at the encoder as a "valid" NDVI = 0 phantom token at every cloud-masked S2 timestep.

Derive the NDVI mask from the upstream B4 / B8 masks instead. The NDVI value is unchanged; only the mask propagation is fixed.

Adds a regression test that builds an input with masked S2 timesteps and asserts the NDVI mask is True at those positions.