### PR TITLE
adding lalon masking with prob

### DIFF
--- a/prometheo/models/presto/single_file_presto.py
+++ b/prometheo/models/presto/single_file_presto.py
@@ -310,6 +310,7 @@ class Encoder(nn.Module):
         mlp_ratio=2,
         num_heads=8,
         max_sequence_length=24,
+        latlon_mask_prob: float = 0.0,
     ):
         super().__init__()
 
@@ -335,6 +336,14 @@ class Encoder(nn.Module):
             num_embeddings=NUM_DYNAMIC_WORLD_CLASSES + 1, embedding_dim=embedding_size
         )
         self.latlon_embed = nn.Linear(3, embedding_size)
+
+        # Location null-masking ("modality dropout" on lat/lon). During training,
+        # with probability ``latlon_mask_prob`` the per-sample latlon token is
+        # replaced by ``null_latlon`` — a learned, location-INDEPENDENT embedding —
+        # so the model must predict from spectral/temporal evidence for those
+        # samples. Default 0.0 = no behaviour change.
+        self.latlon_mask_prob = latlon_mask_prob
+        self.null_latlon = nn.Parameter(torch.zeros(embedding_size))
 
         self.blocks = nn.ModuleList(
             [
@@ -547,6 +556,18 @@ class Encoder(nn.Module):
         x, orig_indices, upd_mask = self.mask_tokens(x, mask)
         # append latlon tokens
         latlon_tokens = self.latlon_embed(self.cartesian(latlons)).unsqueeze(1)
+        latlon_mask_prob = getattr(self, "latlon_mask_prob", 0.0)
+        if self.training and latlon_mask_prob > 0.0:
+            # Per-sample null-masking of the location token: with prob
+            # latlon_mask_prob, swap in the learned location-independent
+            # null_latlon so the model cannot rely on coordinates for those
+            # samples (breaks the location shortcut). Eval/inference is untouched.
+            drop = (
+                torch.rand(latlon_tokens.shape[0], device=latlon_tokens.device)
+                < latlon_mask_prob
+            )
+            null = self.null_latlon.to(latlon_tokens.dtype).view(1, 1, -1)
+            latlon_tokens = torch.where(drop.view(-1, 1, 1), null, latlon_tokens)
         x = torch.cat((latlon_tokens, x), dim=1)
         upd_mask = torch.cat(
             (torch.zeros(x.shape[0])[:, None].to(device), upd_mask), dim=1

--- a/prometheo/models/presto/single_file_presto.py
+++ b/prometheo/models/presto/single_file_presto.py
@@ -590,9 +590,10 @@ class Encoder(nn.Module):
             if eval_pooling == "global":
                 # set masked tokens to 0
                 x_for_mean = x * (1 - upd_mask.unsqueeze(-1))
-                x_mean = x_for_mean.sum(dim=1) / torch.sum(
-                    1 - upd_mask, -1, keepdim=True
+                valid_count = torch.clamp(
+                    torch.sum(1 - upd_mask, -1, keepdim=True), min=1.0
                 )
+                x_mean = x_for_mean.sum(dim=1) / valid_count
                 return self.norm(x_mean)
             else:
                 filled_x = self.add_masked_tokens_with_zeros(x, orig_indices, upd_mask)
@@ -603,9 +604,12 @@ class Encoder(nn.Module):
                 )
                 # x, mask have shape [b, timesteps, token_per_timesteps, dim]
                 x_for_mean = x_per_timestep * (1 - mask_per_timestep.unsqueeze(-1))
-                x_mean = x_for_mean.sum(dim=2) / torch.sum(
-                    1 - mask_per_timestep, -1, keepdim=True
+                # clamp denominator to >=1 so fully-masked timesteps yield a
+                # zero embedding rather than NaN (0/0).  
+                valid_count = torch.clamp(
+                    torch.sum(1 - mask_per_timestep, -1, keepdim=True), min=1.0
                 )
+                x_mean = x_for_mean.sum(dim=2) / valid_count
                 return self.norm(x_mean)
 
         return self.norm(x), orig_indices, upd_mask

--- a/prometheo/models/presto/single_file_presto.py
+++ b/prometheo/models/presto/single_file_presto.py
@@ -908,6 +908,7 @@ class Presto(nn.Module):
         decoder_depth=2,
         decoder_num_heads=8,
         max_sequence_length=24,
+        latlon_mask_prob: float = 0.0,
     ):
         encoder = Encoder(
             embedding_size=encoder_embedding_size,
@@ -917,6 +918,7 @@ class Presto(nn.Module):
             mlp_ratio=mlp_ratio,
             num_heads=encoder_num_heads,
             max_sequence_length=max_sequence_length,
+            latlon_mask_prob=latlon_mask_prob,
         )
         decoder = Decoder(
             channel_embeddings=encoder.channel_embed,

--- a/prometheo/models/presto/wrapper.py
+++ b/prometheo/models/presto/wrapper.py
@@ -278,11 +278,24 @@ def load_presto_weights(
         presto_model_layers = torch.load(
             io.BytesIO(response.content), map_location=device
         )
-        presto_model.load_state_dict(presto_model_layers, strict=strict)
     else:
-        presto_model.load_state_dict(
-            torch.load(weights_path, map_location=device), strict=strict
-        )
+        presto_model_layers = torch.load(weights_path, map_location=device)
+
+    missing, unexpected = presto_model.load_state_dict(
+        presto_model_layers, strict=False
+    )
+    if strict:
+        # `null_latlon` is a new, optional learnable token (added for lat/lon
+        # null-masking). It is intentionally absent from older checkpoints and is
+        # kept at its fresh initialisation, so tolerate only that missing key —
+        # strict loading still flags every other missing/unexpected key.
+        missing = [k for k in missing if not k.endswith("null_latlon")]
+        if missing or unexpected:
+            raise RuntimeError(
+                "Error(s) in loading state_dict for "
+                f"{presto_model.__class__.__name__}: "
+                f"Missing key(s): {missing}; Unexpected key(s): {unexpected}."
+            )
 
     return presto_model
 

--- a/prometheo/models/presto/wrapper.py
+++ b/prometheo/models/presto/wrapper.py
@@ -306,6 +306,7 @@ class PretrainedPrestoWrapper(nn.Module):
         num_outputs: Optional[int] = None,
         regression: Optional[bool] = None,
         pretrained_model_path: Optional[Union[str, Path]] = None,
+        latlon_mask_prob: float = 0.0,
     ):
         """Initialize the Presto model through a prometheo wrapper.
 
@@ -319,6 +320,8 @@ class PretrainedPrestoWrapper(nn.Module):
             Needs to be specified when num_outputs is not None.
         pretrained_model_path : Union[str, Path], optional
             The path to the pretrained model, by default None.
+        latlon_mask_prob : float, optional
+            Probability of replacing the lat/lon token with a null embedding during training.
 
         Raises
         ------
@@ -329,7 +332,7 @@ class PretrainedPrestoWrapper(nn.Module):
         super().__init__()
 
         # Construct original Presto model with the default configuration
-        presto = Presto.construct()
+        presto = Presto.construct(latlon_mask_prob=latlon_mask_prob)
 
         # Load pretrained model before making any adaptations
         if pretrained_model_path is not None:


### PR DESCRIPTION
* Adds `Encoder(latlon_mask_prob=0.0)` + a `null_latlon` token; 
* During **training only**, replaces the lat/lon token with the null embedding for `p` of samples to break the location-embedding shortcut;
* Default is 0 (masking off) → no change to existing runs.