### PR TITLE
Latlon masking

### DIFF
--- a/prometheo/models/presto/single_file_presto.py
+++ b/prometheo/models/presto/single_file_presto.py
@@ -310,11 +310,19 @@ class Encoder(nn.Module):
         mlp_ratio=2,
         num_heads=8,
         max_sequence_length=24,
+        latlon_dropout: float = 0.0,
     ):
         super().__init__()
 
         self.band_groups = BANDS_GROUPS_IDX
         self.embedding_size = embedding_size
+        # probability with which the latlon token is masked out during training.
+        # if 0, the latlon token is always kept.
+        if not (0.0 <= latlon_dropout <= 1.0):
+            raise ValueError(
+                f"latlon_dropout must be in [0, 1], got {latlon_dropout}"
+            )
+        self.latlon_dropout = latlon_dropout
 
         # this is used for the channel embedding
         self.band_group_to_idx = {
@@ -548,9 +556,16 @@ class Encoder(nn.Module):
         # append latlon tokens
         latlon_tokens = self.latlon_embed(self.cartesian(latlons)).unsqueeze(1)
         x = torch.cat((latlon_tokens, x), dim=1)
-        upd_mask = torch.cat(
-            (torch.zeros(x.shape[0])[:, None].to(device), upd_mask), dim=1
-        )
+        # by default the latlon token is always kept (mask value 0). If latlon
+        # dropout is enabled, drop (mask) it per-example with the given
+        # probability while training so the model learns to cope without it.
+        if self.training and (self.latlon_dropout > 0):
+            latlon_mask = torch.bernoulli(
+                torch.full((x.shape[0], 1), self.latlon_dropout, device=device)
+            )
+        else:
+            latlon_mask = torch.zeros(x.shape[0])[:, None].to(device)
+        upd_mask = torch.cat((latlon_mask, upd_mask), dim=1)
         orig_indices = torch.cat(
             (torch.zeros(x.shape[0])[:, None].to(device).int(), orig_indices + 1),
             dim=1,
@@ -883,6 +898,7 @@ class Presto(nn.Module):
         decoder_depth=2,
         decoder_num_heads=8,
         max_sequence_length=24,
+        latlon_dropout: float = 0.0,
     ):
         encoder = Encoder(
             embedding_size=encoder_embedding_size,
@@ -892,6 +908,7 @@ class Presto(nn.Module):
             mlp_ratio=mlp_ratio,
             num_heads=encoder_num_heads,
             max_sequence_length=max_sequence_length,
+            latlon_dropout=latlon_dropout,
         )
         decoder = Decoder(
             channel_embeddings=encoder.channel_embed,

--- a/prometheo/models/presto/wrapper.py
+++ b/prometheo/models/presto/wrapper.py
@@ -293,6 +293,7 @@ class PretrainedPrestoWrapper(nn.Module):
         num_outputs: Optional[int] = None,
         regression: Optional[bool] = None,
         pretrained_model_path: Optional[Union[str, Path]] = None,
+        latlon_dropout: float = 0.0,
     ):
         """Initialize the Presto model through a prometheo wrapper.
 
@@ -306,6 +307,9 @@ class PretrainedPrestoWrapper(nn.Module):
             Needs to be specified when num_outputs is not None.
         pretrained_model_path : Union[str, Path], optional
             The path to the pretrained model, by default None.
+        latlon_dropout : float, optional
+            Probability with which the latlon token is masked out during
+            training. If 0 (default), the latlon token is always kept.
 
         Raises
         ------
@@ -316,7 +320,7 @@ class PretrainedPrestoWrapper(nn.Module):
         super().__init__()
 
         # Construct original Presto model with the default configuration
-        presto = Presto.construct()
+        presto = Presto.construct(latlon_dropout=latlon_dropout)
 
         # Load pretrained model before making any adaptations
         if pretrained_model_path is not None:

--- a/tests/test_presto.py
+++ b/tests/test_presto.py
@@ -157,6 +157,74 @@ class TestPresto(unittest.TestCase):
         )
 
 
+class TestLatlonDropout(unittest.TestCase):
+    @staticmethod
+    def _make_predictors(latlon, s1, timestamps):
+        return Predictors(s1=s1, latlon=latlon, timestamps=timestamps)
+
+    def _fixed_inputs(self):
+        b, t, h, w = 4, 4, 1, 1
+        timestamps_per_instance = np.array([[2020, m + 1, 1] for m in range(t)])
+        rng = np.random.RandomState(0)
+        s1 = rng.rand(b, h, w, t, len(S1_BANDS))
+        timestamps = repeat(timestamps_per_instance, "t d -> b t d", b=b)
+        latlon_a = np.zeros((b, h, w, 2))
+        latlon_b = np.full((b, h, w, 2), 45.0)
+        return s1, timestamps, latlon_a, latlon_b
+
+    def test_full_dropout_masks_latlon_during_training(self):
+        # With latlon_dropout=1.0 in train mode the latlon token is always
+        # masked, so the embeddings must be invariant to the latlon values.
+        s1, timestamps, latlon_a, latlon_b = self._fixed_inputs()
+        model = Presto(latlon_dropout=1.0)
+        model.train()
+        out_a = model(
+            self._make_predictors(latlon_a, s1, timestamps),
+            eval_pooling=PoolingMethods.GLOBAL,
+        )
+        out_b = model(
+            self._make_predictors(latlon_b, s1, timestamps),
+            eval_pooling=PoolingMethods.GLOBAL,
+        )
+        self.assertTrue(torch.allclose(out_a, out_b))
+
+    def test_no_dropout_keeps_latlon(self):
+        # Without dropout the latlon token is kept, so different latlons must
+        # produce different embeddings.
+        s1, timestamps, latlon_a, latlon_b = self._fixed_inputs()
+        model = Presto(latlon_dropout=0.0)
+        model.train()
+        out_a = model(
+            self._make_predictors(latlon_a, s1, timestamps),
+            eval_pooling=PoolingMethods.GLOBAL,
+        )
+        out_b = model(
+            self._make_predictors(latlon_b, s1, timestamps),
+            eval_pooling=PoolingMethods.GLOBAL,
+        )
+        self.assertFalse(torch.allclose(out_a, out_b))
+
+    def test_dropout_disabled_in_eval_mode(self):
+        # Dropout only applies while training; in eval mode the latlon token is
+        # kept even with latlon_dropout=1.0.
+        s1, timestamps, latlon_a, latlon_b = self._fixed_inputs()
+        model = Presto(latlon_dropout=1.0)
+        model.eval()
+        out_a = model(
+            self._make_predictors(latlon_a, s1, timestamps),
+            eval_pooling=PoolingMethods.GLOBAL,
+        )
+        out_b = model(
+            self._make_predictors(latlon_b, s1, timestamps),
+            eval_pooling=PoolingMethods.GLOBAL,
+        )
+        self.assertFalse(torch.allclose(out_a, out_b))
+
+    def test_invalid_dropout_raises(self):
+        with self.assertRaises(ValueError):
+            Presto(latlon_dropout=1.5)
+
+
 class TestNormalize(unittest.TestCase):
     def test_ndvi_mask_propagated_at_masked_s2_timesteps(self):
         # Regression: when S2 is masked at the input, the NDVI position


### PR DESCRIPTION
Unlike https://github.com/WorldCereal/prometheo/pull/47, we don't learn a "mask latlon token" parameter - instead, we just mark the latlon token as masked so its ignored by the attention mechanism. 