### PR TITLE
Faster

### DIFF
--- a/prometheo/models/presto/single_file_presto.py
+++ b/prometheo/models/presto/single_file_presto.py
@@ -280,7 +280,9 @@ def month_to_tensor(
     if isinstance(month, int):
         assert cast(int, month) < 12
     else:
-        assert max(cast(torch.Tensor, month.flatten())) < 12
+        # Single tensor reduction — python max() would iterate the tensor
+        # element-wise (one device op per element on CUDA inputs).
+        assert int(cast(torch.Tensor, month).max()) < 12
 
     if isinstance(month, int):
         # >>> torch.fmod(torch.tensor([9., 10, 11, 12, 13, 14]), 12)

--- a/prometheo/models/presto/wrapper.py
+++ b/prometheo/models/presto/wrapper.py
@@ -149,9 +149,7 @@ def normalize(x: np.ndarray, mask: np.ndarray):
         BANDS.index("NDVI"),
     )
     if isinstance(x, np.ndarray):
-        ndvi_mask_from_input = np.logical_or(
-            mask[..., b4_idx], mask[..., b8_idx]
-        )
+        ndvi_mask_from_input = np.logical_or(mask[..., b4_idx], mask[..., b8_idx])
     else:
         ndvi_mask_from_input = torch.logical_or(
             mask[..., b4_idx].bool(), mask[..., b8_idx].bool()
@@ -166,7 +164,7 @@ def normalize(x: np.ndarray, mask: np.ndarray):
     return x, mask
 
 
-def dataset_to_model(x: Predictors):
+def dataset_to_model(x: Predictors, device: Optional[torch.device] = None):
     batch_sizes = [v.shape[0] for v in [x.s1, x.s2, x.meteo, x.dem] if v is not None]
     timesteps = [v.shape[-2] for v in [x.s1, x.s2, x.meteo] if v is not None]
     hs = [v.shape[1] for v in [x.s1, x.s2, x.dem, x.latlon] if v is not None]
@@ -189,58 +187,143 @@ def dataset_to_model(x: Predictors):
     batch_size, timesteps = batch_sizes[0], timesteps[0]
     total_bands = sum([len(v) for _, v in BANDS_GROUPS_IDX.items()])
 
-    mask, output = (
-        np.ones((batch_size, h, w, timesteps, total_bands)),
-        np.zeros((batch_size, h, w, timesteps, total_bands)),
-    )
+    if device is not None:
+        # Torch-native path: assemble and normalize on `device` in float32.
+        # This avoids a per-batch float64 CPU allocation and serialization with the GPU.
+        s1 = _to_device_tensor(x.s1, device) if x.s1 is not None else None
+        s2 = _to_device_tensor(x.s2, device) if x.s2 is not None else None
+        meteo = _to_device_tensor(x.meteo, device) if x.meteo is not None else None
+        dem = _to_device_tensor(x.dem, device) if x.dem is not None else None
 
-    if x.s1 is not None:
-        # for some reason, doing
-        # x.s1[ :, 0, 0, :, mapper["S1"]["predictor"]]
-        # directly yields an array of shape [bands, batch_size, timesteps]
-        # but splitting it like this doesn't. I am not sure why
-        s1_hw = x.s1[:, :, :, :, :]
-        s1_hw_bands = s1_hw[:, :, :, :, mapper["S1"]["predictor"]]
-        output[:, :, :, :, mapper["S1"]["presto"]] = s1_hw_bands
-        mask[:, :, :, :, mapper["S1"]["presto"]] = s1_hw_bands == NODATAVALUE
-
-    if x.s2 is not None:
-        s2_hw = x.s2[:, :, :, :, :]
-        s2_hw_bands = s2_hw[:, :, :, :, mapper["S2"]["predictor"]]
-        output[:, :, :, :, mapper["S2"]["presto"]] = s2_hw_bands
-        mask[:, :, :, :, mapper["S2"]["presto"]] = s2_hw_bands == NODATAVALUE
-
-    if x.dem is not None:
-        dem_with_time = repeat(
-            x.dem[:, :, :, mapper["dem"]["predictor"]],
-            "b h w d -> b h w t d",
-            t=timesteps,
+        output = torch.zeros(
+            (batch_size, h, w, timesteps, total_bands),
+            dtype=torch.float32,
+            device=device,
         )
-        output[:, :, :, :, mapper["dem"]["presto"]] = dem_with_time
-        mask[:, :, :, :, mapper["dem"]["presto"]] = dem_with_time == NODATAVALUE
+        mask = torch.ones(
+            (batch_size, h, w, timesteps, total_bands),
+            dtype=torch.bool,
+            device=device,
+        )
 
-    if x.meteo is not None:
-        meteo_hw = x.meteo[:, :, :, :, :]
-        meteo_hw_bands = meteo_hw[:, :, :, :, mapper["meteo"]["predictor"]]
-        output[:, :, :, :, mapper["meteo"]["presto"]] = meteo_hw_bands
-        mask[:, :, :, :, mapper["meteo"]["presto"]] = meteo_hw_bands == NODATAVALUE
+        def _fill(group: str, values: torch.Tensor):
+            values = values.to(torch.float32)
+            presto_idx = mapper[group]["presto"]
+            output[..., presto_idx] = values
+            mask[..., presto_idx] = values == NODATAVALUE
 
-    dynamic_world = np.ones((batch_size * h * w, timesteps)) * NUM_DYNAMIC_WORLD_CLASSES
+        if s1 is not None:
+            _fill("S1", s1[..., mapper["S1"]["predictor"]])
+        if s2 is not None:
+            _fill("S2", s2[..., mapper["S2"]["predictor"]])
+        if dem is not None:
+            dem_with_time = (
+                dem[..., mapper["dem"]["predictor"]]
+                .unsqueeze(3)
+                .expand(-1, -1, -1, timesteps, -1)
+            )
+            _fill("dem", dem_with_time)
+        if meteo is not None:
+            _fill("meteo", meteo[..., mapper["meteo"]["predictor"]])
 
-    latlon: Union[ArrayTensor, None] = None
-    if x.latlon is not None:
-        latlon = rearrange(x.latlon, "b h w d -> (b h w) d")
+        dynamic_world = torch.full(
+            (batch_size * h * w, timesteps),
+            NUM_DYNAMIC_WORLD_CLASSES,
+            dtype=torch.long,
+            device=device,
+        )
 
-    timestamps: Union[ArrayTensor, None] = None
-    if x.timestamps is not None:
-        timestamps = repeat(x.timestamps, "b t d -> b h w t d", h=h, w=w)
-        timestamps = rearrange(timestamps, "b h w t d -> (b h w) t d")
+        latlon: Union[ArrayTensor, None] = None
+        if x.latlon is not None:
+            latlon = rearrange(
+                _to_device_tensor(x.latlon, device).to(torch.float32),
+                "b h w d -> (b h w) d",
+            )
 
-    output = rearrange(output, "b h w t d -> (b h w) t d")
-    mask = rearrange(mask, "b h w t d -> (b h w) t d")
+        timestamps: Union[ArrayTensor, None] = None
+        if x.timestamps is not None:
+            timestamps = _to_device_tensor(x.timestamps, device).long()
+            timestamps = repeat(timestamps, "b t d -> b h w t d", h=h, w=w)
+            timestamps = rearrange(timestamps, "b h w t d -> (b h w) t d")
 
-    output, mask = normalize(output, mask)
-    return output, mask, dynamic_world, latlon, timestamps, h, w
+        output = rearrange(output, "b h w t d -> (b h w) t d")
+        mask = rearrange(mask, "b h w t d -> (b h w) t d")
+
+        bands_add, bands_div = _normalize_constants(device, torch.float32)
+        output = (output + bands_add) / bands_div
+
+        b4_idx, b8_idx, ndvi_idx = (
+            BANDS.index("B4"),
+            BANDS.index("B8"),
+            BANDS.index("NDVI"),
+        )
+        band_1 = output[..., b8_idx]
+        band_2 = output[..., b4_idx]
+        denom = band_1 + band_2
+        ndvi = torch.where(
+            denom > 0, (band_1 - band_2) / denom, torch.zeros_like(denom)
+        )
+        output[..., ndvi_idx] = ndvi
+        mask[..., ndvi_idx] = mask[..., b8_idx] | mask[..., b4_idx]
+
+        return output, mask.long(), dynamic_world, latlon, timestamps, h, w
+
+    else:
+        # NumPy path (CPU, used e.g. during inference without a GPU).
+        mask, output = (
+            np.ones((batch_size, h, w, timesteps, total_bands)),
+            np.zeros((batch_size, h, w, timesteps, total_bands)),
+        )
+
+        if x.s1 is not None:
+            # for some reason, doing
+            # x.s1[ :, 0, 0, :, mapper["S1"]["predictor"]]
+            # directly yields an array of shape [bands, batch_size, timesteps]
+            # but splitting it like this doesn't. I am not sure why
+            s1_hw = x.s1[:, :, :, :, :]
+            s1_hw_bands = s1_hw[:, :, :, :, mapper["S1"]["predictor"]]
+            output[:, :, :, :, mapper["S1"]["presto"]] = s1_hw_bands
+            mask[:, :, :, :, mapper["S1"]["presto"]] = s1_hw_bands == NODATAVALUE
+
+        if x.s2 is not None:
+            s2_hw = x.s2[:, :, :, :, :]
+            s2_hw_bands = s2_hw[:, :, :, :, mapper["S2"]["predictor"]]
+            output[:, :, :, :, mapper["S2"]["presto"]] = s2_hw_bands
+            mask[:, :, :, :, mapper["S2"]["presto"]] = s2_hw_bands == NODATAVALUE
+
+        if x.dem is not None:
+            dem_with_time = repeat(
+                x.dem[:, :, :, mapper["dem"]["predictor"]],
+                "b h w d -> b h w t d",
+                t=timesteps,
+            )
+            output[:, :, :, :, mapper["dem"]["presto"]] = dem_with_time
+            mask[:, :, :, :, mapper["dem"]["presto"]] = dem_with_time == NODATAVALUE
+
+        if x.meteo is not None:
+            meteo_hw = x.meteo[:, :, :, :, :]
+            meteo_hw_bands = meteo_hw[:, :, :, :, mapper["meteo"]["predictor"]]
+            output[:, :, :, :, mapper["meteo"]["presto"]] = meteo_hw_bands
+            mask[:, :, :, :, mapper["meteo"]["presto"]] = meteo_hw_bands == NODATAVALUE
+
+        dynamic_world = (
+            np.ones((batch_size * h * w, timesteps)) * NUM_DYNAMIC_WORLD_CLASSES
+        )
+
+        latlon: Union[ArrayTensor, None] = None
+        if x.latlon is not None:
+            latlon = rearrange(x.latlon, "b h w d -> (b h w) d")
+
+        timestamps: Union[ArrayTensor, None] = None
+        if x.timestamps is not None:
+            timestamps = repeat(x.timestamps, "b t d -> b h w t d", h=h, w=w)
+            timestamps = rearrange(timestamps, "b h w t d -> (b h w) t d")
+
+        output = rearrange(output, "b h w t d -> (b h w) t d")
+        mask = rearrange(mask, "b h w t d -> (b h w) t d")
+
+        output, mask = normalize(output, mask)
+        return output, mask, dynamic_world, latlon, timestamps, h, w
 
 
 _NORMALIZE_CONSTANTS: dict = {}
@@ -261,120 +344,6 @@ def _to_device_tensor(v, device: torch.device, non_blocking: bool = True):
     if isinstance(v, np.ndarray):
         v = torch.from_numpy(v)
     return v.to(device, non_blocking=non_blocking)
-
-
-def dataset_to_model_torch(x: Predictors, device: torch.device):
-    """Torch-native equivalent of `dataset_to_model`.
-
-    Moves the (small) predictor tensors to `device` first and assembles the
-    presto input cube there in float32. The numpy implementation runs on a
-    single CPU core in the main process for every batch (in float64), which
-    serializes with the GPU; this version reduces the per-batch main-process
-    cost to a handful of async host-to-device copies.
-    """
-    s1 = _to_device_tensor(x.s1, device) if x.s1 is not None else None
-    s2 = _to_device_tensor(x.s2, device) if x.s2 is not None else None
-    meteo = _to_device_tensor(x.meteo, device) if x.meteo is not None else None
-    dem = _to_device_tensor(x.dem, device) if x.dem is not None else None
-    latlon_in = x.latlon
-    timestamps_in = x.timestamps
-
-    batch_sizes = [v.shape[0] for v in [s1, s2, meteo, dem] if v is not None]
-    timesteps_list = [v.shape[-2] for v in [s1, s2, meteo] if v is not None]
-    hs = [v.shape[1] for v in [s1, s2, dem] if v is not None]
-    ws = [v.shape[2] for v in [s1, s2, dem] if v is not None]
-    if latlon_in is not None:
-        hs.append(latlon_in.shape[1])
-        ws.append(latlon_in.shape[2])
-    if len(timesteps_list) == 0:
-        raise ValueError("One of s1, s2, meteo must be not None")
-    if len(hs) == 0:
-        raise ValueError("One of s1, s2, dem must be not None")
-    if not len(set(batch_sizes)) == 1:
-        raise ValueError("dim 0 (batch size) must be consistent for s1, s2, dem, meteo")
-    if not len(set(timesteps_list)) == 1:
-        raise ValueError("dim -2 (timesteps) must be consistent for s1, s2, meteo")
-    if not len(set(hs)) == 1:
-        raise ValueError("dim 1 (height) must be consistent for s1, s2, dem, latlon")
-    h = hs[0]
-    if not len(set(ws)) == 1:
-        raise ValueError("dim 2 (width) must be consistent for s1, s2, dem, latlon")
-    w = ws[0]
-
-    batch_size, timesteps = batch_sizes[0], timesteps_list[0]
-    total_bands = sum([len(v) for _, v in BANDS_GROUPS_IDX.items()])
-
-    output = torch.zeros(
-        (batch_size, h, w, timesteps, total_bands),
-        dtype=torch.float32,
-        device=device,
-    )
-    mask = torch.ones(
-        (batch_size, h, w, timesteps, total_bands),
-        dtype=torch.bool,
-        device=device,
-    )
-
-    def _fill(group: str, values: torch.Tensor):
-        values = values.to(torch.float32)
-        presto_idx = mapper[group]["presto"]
-        output[..., presto_idx] = values
-        mask[..., presto_idx] = values == NODATAVALUE
-
-    if s1 is not None:
-        _fill("S1", s1[..., mapper["S1"]["predictor"]])
-    if s2 is not None:
-        _fill("S2", s2[..., mapper["S2"]["predictor"]])
-    if dem is not None:
-        dem_with_time = (
-            dem[..., mapper["dem"]["predictor"]]
-            .unsqueeze(3)
-            .expand(-1, -1, -1, timesteps, -1)
-        )
-        _fill("dem", dem_with_time)
-    if meteo is not None:
-        _fill("meteo", meteo[..., mapper["meteo"]["predictor"]])
-
-    dynamic_world = torch.full(
-        (batch_size * h * w, timesteps),
-        NUM_DYNAMIC_WORLD_CLASSES,
-        dtype=torch.long,
-        device=device,
-    )
-
-    latlon = None
-    if latlon_in is not None:
-        latlon = rearrange(
-            _to_device_tensor(latlon_in, device).to(torch.float32),
-            "b h w d -> (b h w) d",
-        )
-
-    timestamps = None
-    if timestamps_in is not None:
-        timestamps = _to_device_tensor(timestamps_in, device).long()
-        timestamps = repeat(timestamps, "b t d -> b h w t d", h=h, w=w)
-        timestamps = rearrange(timestamps, "b h w t d -> (b h w) t d")
-
-    output = rearrange(output, "b h w t d -> (b h w) t d")
-    mask = rearrange(mask, "b h w t d -> (b h w) t d")
-
-    # normalize() equivalent, in float32 on `device`
-    bands_add, bands_div = _normalize_constants(device, torch.float32)
-    output = (output + bands_add) / bands_div
-
-    b4_idx, b8_idx, ndvi_idx = (
-        BANDS.index("B4"),
-        BANDS.index("B8"),
-        BANDS.index("NDVI"),
-    )
-    band_1 = output[..., b8_idx]
-    band_2 = output[..., b4_idx]
-    denom = band_1 + band_2
-    ndvi = torch.where(denom > 0, (band_1 - band_2) / denom, torch.zeros_like(denom))
-    output[..., ndvi_idx] = ndvi
-    mask[..., ndvi_idx] = mask[..., b8_idx] | mask[..., b4_idx]
-
-    return output, mask.long(), dynamic_world, latlon, timestamps, h, w
 
 
 @lru_cache(maxsize=6)
@@ -525,7 +494,7 @@ class PretrainedPrestoWrapper(nn.Module):
 
         model_device = self.encoder.pos_embed.device
         s1_s2_era5_srtm, mask, dynamic_world, latlon, timestamps, h, w = (
-            dataset_to_model_torch(x, model_device)
+            dataset_to_model(x, device=model_device)
         )
 
         # labels should have shape [B, H, W, T or 1, num_outputs].

--- a/prometheo/models/presto/wrapper.py
+++ b/prometheo/models/presto/wrapper.py
@@ -18,7 +18,6 @@ from prometheo.predictors import (
     S2_BANDS,
     ArrayTensor,
     Predictors,
-    to_torchtensor,
 )
 from prometheo.utils import device
 

--- a/prometheo/models/presto/wrapper.py
+++ b/prometheo/models/presto/wrapper.py
@@ -309,11 +309,11 @@ def dataset_to_model(x: Predictors, device: Optional[torch.device] = None):
             np.ones((batch_size * h * w, timesteps)) * NUM_DYNAMIC_WORLD_CLASSES
         )
 
-        latlon: Union[ArrayTensor, None] = None
+        latlon = None
         if x.latlon is not None:
             latlon = rearrange(x.latlon, "b h w d -> (b h w) d")
 
-        timestamps: Union[ArrayTensor, None] = None
+        timestamps = None
         if x.timestamps is not None:
             timestamps = repeat(x.timestamps, "b t d -> b h w t d", h=h, w=w)
             timestamps = rearrange(timestamps, "b h w t d -> (b h w) t d")

--- a/prometheo/models/presto/wrapper.py
+++ b/prometheo/models/presto/wrapper.py
@@ -243,6 +243,140 @@ def dataset_to_model(x: Predictors):
     return output, mask, dynamic_world, latlon, timestamps, h, w
 
 
+_NORMALIZE_CONSTANTS: dict = {}
+
+
+def _normalize_constants(device: torch.device, dtype: torch.dtype):
+    """Cache (BANDS_ADD, BANDS_DIV) tensors per device/dtype."""
+    key = (device, dtype)
+    if key not in _NORMALIZE_CONSTANTS:
+        _NORMALIZE_CONSTANTS[key] = (
+            torch.tensor(BANDS_ADD, device=device, dtype=dtype),
+            torch.tensor(BANDS_DIV, device=device, dtype=dtype),
+        )
+    return _NORMALIZE_CONSTANTS[key]
+
+
+def _to_device_tensor(v, device: torch.device, non_blocking: bool = True):
+    if isinstance(v, np.ndarray):
+        v = torch.from_numpy(v)
+    return v.to(device, non_blocking=non_blocking)
+
+
+def dataset_to_model_torch(x: Predictors, device: torch.device):
+    """Torch-native equivalent of `dataset_to_model`.
+
+    Moves the (small) predictor tensors to `device` first and assembles the
+    presto input cube there in float32. The numpy implementation runs on a
+    single CPU core in the main process for every batch (in float64), which
+    serializes with the GPU; this version reduces the per-batch main-process
+    cost to a handful of async host-to-device copies.
+    """
+    s1 = _to_device_tensor(x.s1, device) if x.s1 is not None else None
+    s2 = _to_device_tensor(x.s2, device) if x.s2 is not None else None
+    meteo = _to_device_tensor(x.meteo, device) if x.meteo is not None else None
+    dem = _to_device_tensor(x.dem, device) if x.dem is not None else None
+    latlon_in = x.latlon
+    timestamps_in = x.timestamps
+
+    batch_sizes = [v.shape[0] for v in [s1, s2, meteo, dem] if v is not None]
+    timesteps_list = [v.shape[-2] for v in [s1, s2, meteo] if v is not None]
+    hs = [v.shape[1] for v in [s1, s2, dem] if v is not None]
+    ws = [v.shape[2] for v in [s1, s2, dem] if v is not None]
+    if latlon_in is not None:
+        hs.append(latlon_in.shape[1])
+        ws.append(latlon_in.shape[2])
+    if len(timesteps_list) == 0:
+        raise ValueError("One of s1, s2, meteo must be not None")
+    if len(hs) == 0:
+        raise ValueError("One of s1, s2, dem must be not None")
+    if not len(set(batch_sizes)) == 1:
+        raise ValueError("dim 0 (batch size) must be consistent for s1, s2, dem, meteo")
+    if not len(set(timesteps_list)) == 1:
+        raise ValueError("dim -2 (timesteps) must be consistent for s1, s2, meteo")
+    if not len(set(hs)) == 1:
+        raise ValueError("dim 1 (height) must be consistent for s1, s2, dem, latlon")
+    h = hs[0]
+    if not len(set(ws)) == 1:
+        raise ValueError("dim 2 (width) must be consistent for s1, s2, dem, latlon")
+    w = ws[0]
+
+    batch_size, timesteps = batch_sizes[0], timesteps_list[0]
+    total_bands = sum([len(v) for _, v in BANDS_GROUPS_IDX.items()])
+
+    output = torch.zeros(
+        (batch_size, h, w, timesteps, total_bands),
+        dtype=torch.float32,
+        device=device,
+    )
+    mask = torch.ones(
+        (batch_size, h, w, timesteps, total_bands),
+        dtype=torch.bool,
+        device=device,
+    )
+
+    def _fill(group: str, values: torch.Tensor):
+        values = values.to(torch.float32)
+        presto_idx = mapper[group]["presto"]
+        output[..., presto_idx] = values
+        mask[..., presto_idx] = values == NODATAVALUE
+
+    if s1 is not None:
+        _fill("S1", s1[..., mapper["S1"]["predictor"]])
+    if s2 is not None:
+        _fill("S2", s2[..., mapper["S2"]["predictor"]])
+    if dem is not None:
+        dem_with_time = (
+            dem[..., mapper["dem"]["predictor"]]
+            .unsqueeze(3)
+            .expand(-1, -1, -1, timesteps, -1)
+        )
+        _fill("dem", dem_with_time)
+    if meteo is not None:
+        _fill("meteo", meteo[..., mapper["meteo"]["predictor"]])
+
+    dynamic_world = torch.full(
+        (batch_size * h * w, timesteps),
+        NUM_DYNAMIC_WORLD_CLASSES,
+        dtype=torch.long,
+        device=device,
+    )
+
+    latlon = None
+    if latlon_in is not None:
+        latlon = rearrange(
+            _to_device_tensor(latlon_in, device).to(torch.float32),
+            "b h w d -> (b h w) d",
+        )
+
+    timestamps = None
+    if timestamps_in is not None:
+        timestamps = _to_device_tensor(timestamps_in, device).long()
+        timestamps = repeat(timestamps, "b t d -> b h w t d", h=h, w=w)
+        timestamps = rearrange(timestamps, "b h w t d -> (b h w) t d")
+
+    output = rearrange(output, "b h w t d -> (b h w) t d")
+    mask = rearrange(mask, "b h w t d -> (b h w) t d")
+
+    # normalize() equivalent, in float32 on `device`
+    bands_add, bands_div = _normalize_constants(device, torch.float32)
+    output = (output + bands_add) / bands_div
+
+    b4_idx, b8_idx, ndvi_idx = (
+        BANDS.index("B4"),
+        BANDS.index("B8"),
+        BANDS.index("NDVI"),
+    )
+    band_1 = output[..., b8_idx]
+    band_2 = output[..., b4_idx]
+    denom = band_1 + band_2
+    ndvi = torch.where(denom > 0, (band_1 - band_2) / denom, torch.zeros_like(denom))
+    output[..., ndvi_idx] = ndvi
+    mask[..., ndvi_idx] = mask[..., b8_idx] | mask[..., b4_idx]
+
+    return output, mask.long(), dynamic_world, latlon, timestamps, h, w
+
+
 @lru_cache(maxsize=6)
 def load_presto_weights(
     presto_model: Presto,
@@ -389,8 +523,9 @@ class PretrainedPrestoWrapper(nn.Module):
 
         """
 
+        model_device = self.encoder.pos_embed.device
         s1_s2_era5_srtm, mask, dynamic_world, latlon, timestamps, h, w = (
-            dataset_to_model(x)
+            dataset_to_model_torch(x, model_device)
         )
 
         # labels should have shape [B, H, W, T or 1, num_outputs].
@@ -407,14 +542,13 @@ class PretrainedPrestoWrapper(nn.Module):
         if x.timestamps is None:
             raise ValueError("Presto requires input timestamps")
 
-        model_device = self.encoder.pos_embed.device
         embeddings = self.encoder(
-            x=to_torchtensor(s1_s2_era5_srtm, device=model_device).float(),
-            dynamic_world=to_torchtensor(dynamic_world, device=model_device).long(),
-            latlons=to_torchtensor(latlon, device=model_device).float(),
-            mask=to_torchtensor(mask, device=model_device).long(),
+            x=s1_s2_era5_srtm,
+            dynamic_world=dynamic_world,
+            latlons=latlon,
+            mask=mask,
             # presto wants 0 indexed months, not 1 indexed months
-            month=to_torchtensor(timestamps[:, :, 1] - 1, device=model_device),
+            month=timestamps[:, :, 1] - 1,
             eval_pooling=eval_pooling.value if eval_pooling is not None else None,
         )
 


### PR DESCRIPTION
We are trying to speed-up our worldcereal finetuning experiments (global ones were taking around 3 days to run). We found a few optimizations in different repos, worldcereal-classification, worldcereal-finetune and prometheo.

**For prometheo:**
The dataset_to_model function was assembling the full Presto input cube in numpy (float64, CPU) on every batch, even during GPU inference. This serialized with the GPU, the main process was blocked doing a large float64 allocation and normalization before each forward pass.

- First we added `dataset_to_model_torch  `a torch-native version that moves inputs to the target device first and does all assembly and normalization there in float32. Avoids the per-batch float64 CPU allocation entirely. Also caches the normalization constant tensors per device/dtype so they're not re-created each call.
- Then , we merged `dataset_to_model_torch` back into `dataset_to_model `as an optional path with pass `device=...` to get the fast on-device path, omit it to keep the original numpy CPU path. Removed the now-redundant separate function.
- Small fix in `single_file_presto.py`: the month validity assert using Python's max() on tensor, which iterates element-wise and with one device op per element on CUDA inputs. Replaced with .max() on tensor directly so it's a single reduction op.
